### PR TITLE
fix: extract kubectl version properly when CDN adds cache messages

### DIFF
--- a/.github/actions/deploy-to-k8s/action.yml
+++ b/.github/actions/deploy-to-k8s/action.yml
@@ -66,12 +66,17 @@ runs:
       shell: bash
       run: |
         # Fetch kubectl version with retries
-        KUBECTL_VERSION=$(curl -L -sS --retry 3 --retry-delay 2 \
+        KUBECTL_RAW=$(curl -L -sS --retry 3 --retry-delay 2 \
           https://dl.k8s.io/release/stable.txt)
 
-        # Validate that version was fetched successfully
+        # Extract only the version line (vX.Y.Z format) from the response
+        # This handles cases where CDN/cache messages are mixed in the output
+        KUBECTL_VERSION=$(echo "$KUBECTL_RAW" | grep -oE '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+
+        # Validate that version was fetched and has correct format
         if [ -z "$KUBECTL_VERSION" ]; then
-          echo "::error::Failed to get kubectl version from dl.k8s.io"
+          echo "::error::Failed to get valid kubectl version from dl.k8s.io"
+          echo "::error::Raw response was: $KUBECTL_RAW"
           exit 1
         fi
 


### PR DESCRIPTION
## Summary
- Fixes kubectl download failures when CDN returns cache timeout messages mixed with version response
- Extracts only the valid `vX.Y.Z` pattern using grep
- Logs raw response on failure for easier debugging

## Test plan
- [x] Tested locally with simulated CDN garbage response
- [x] Tested with clean response
- [x] Tested with completely invalid response (correctly fails)
- [x] Tested against live dl.k8s.io endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)