### PR TITLE
feat(deploy): add overlay_cluster input to target non-prod clusters

### DIFF
--- a/.github/actions/deploy-to-k8s/action.yml
+++ b/.github/actions/deploy-to-k8s/action.yml
@@ -58,6 +58,10 @@ inputs:
     description: "GitHub token with write access to traventia-gitops repo (for ArgoCD deployments)"
     required: false
     default: ""
+  overlay_cluster:
+    description: "Target GitOps cluster (selects apps/<app>/overlays/<cluster>/<env>). Defaults to eks-i2 (production)."
+    required: false
+    default: "eks-i2"
 runs:
   using: "composite"
   steps:
@@ -108,6 +112,7 @@ runs:
         K8S_USER_NAME: ${{ inputs.k8s_user_name }}
         K8S_NS: ${{ inputs.k8s_namespace }}
         DEPLOY_ENV: ${{ inputs.deploy_env }}
+        DEPLOY_CLUSTER: ${{ inputs.overlay_cluster }}
         IS_BC: ${{ inputs.is_bc }}
         USER_CHANGE: ${{ github.actor }}
         GITHUB_CONTEXT: ${{ toJson(github) }}

--- a/.github/workflows/ts-srv-cicd.yml
+++ b/.github/workflows/ts-srv-cicd.yml
@@ -52,6 +52,11 @@ on:
         required: false
         type: string
         default: "0"
+      overlay_cluster:
+        description: "Target GitOps cluster (selects apps/<app>/overlays/<cluster>/<env>). Defaults to eks-i2 (production)."
+        required: false
+        type: string
+        default: "eks-i2"
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -251,3 +256,4 @@ jobs:
           is_bc: ${{ inputs.is_bc }}
           branch: ${{ github.head_ref || github.ref_name }}
           gitops-token: ${{ secrets.GITOPS_TOKEN }}
+          overlay_cluster: ${{ inputs.overlay_cluster }}


### PR DESCRIPTION
## Qué

Nuevo input opcional **`overlay_cluster`** (default `eks-i2`) en:
- el workflow reutilizable `ts-srv-cicd.yml`, y
- la acción `deploy-to-k8s`,

que se propaga a `deploy_apps.sh` como **`DEPLOY_CLUSTER`**. Selecciona qué árbol de
overlays de GitOps se bumpea: `apps/<app>/overlays/<cluster>/<env>/kustomization.yaml`.

## Por qué

`deploy_apps.sh` ya leía `DEPLOY_CLUSTER` (default `eks-i2`), pero ningún workflow lo
pasaba: prod funcionaba solo por el default. Para desplegar a **eks-dev** hay que poder
pasar `overlay_cluster: eks-dev`.

## Impacto en prod

Nulo. El default `eks-i2` deja los deploys de producción idénticos. Además master usa
`ts-srv-cicd-matrix-recheck-split-runners-ovh.yml`, no este workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)