### PR TITLE
feat(mark-pipeline-status): pasar github.token para 'Falló en…' en el card de fallo de Teams

### DIFF
--- a/.github/actions/mark-pipeline-status/action.yml
+++ b/.github/actions/mark-pipeline-status/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: "Git branch name for branch-aware status tracking"
     required: false
     default: ""
+  github-token:
+    description: "GitHub token (github.token) para consultar qué etapas fallaron al notificar a Teams"
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -56,6 +60,7 @@ runs:
       env:
         APOLO_API_TOKEN: ${{ inputs.apolo-api-token }}
         DEPLOY_BRANCH: ${{ inputs.branch }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
         IFS=',' read -r -a apps <<< "${{ inputs.apps }}"
         for app in "${apps[@]}"; do

--- a/.github/workflows/ts-srv-cicd-matrix-recheck-split-runners-ovh.yml
+++ b/.github/workflows/ts-srv-cicd-matrix-recheck-split-runners-ovh.yml
@@ -459,6 +459,7 @@ jobs:
           environment: ${{ inputs.environment }}
           status: ERROR
           branch: ${{ github.head_ref || github.ref_name }}
+          github-token: ${{ github.token }}
           apolo-api-token: ${{ secrets.APOLO_API_TOKEN }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Qué

Pasa `${{ github.token }}` al job `cleanup-on-failure` → action `mark-pipeline-status` → env `GITHUB_TOKEN`.

`mark_pipeline_status.cjs` (ci-scripts) lo usa para consultar vía GitHub API qué etapas del run fallaron **por app** y meterlas en el card rojo de Teams ("Falló en: unit-tests, integration-tests, build").

## Por qué

El job `cleanup-on-failure` no recibe `GITHUB_CONTEXT` ni token, así que no podía saber qué falló por app (los `needs.*.result` son agregados de la matriz). Con el token consulta `/actions/runs/{id}/jobs`.

## Alcance / seguridad

- Aditivo: input `github-token` **opcional** (default `""`). Si no se pasa, el card sale igual pero sin la línea "Falló en…" (el código lo maneja, no rompe).
- Afecta a todos los repos que usan este reusable, pero solo añade contexto al card de fallo ya existente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)